### PR TITLE
Change to move randomly if not visible to the agent.

### DIFF
--- a/examples/vision/example.jl
+++ b/examples/vision/example.jl
@@ -4,6 +4,7 @@ using Gen, GenParticleFilters
 using PDDLViz, GLMakie
 
 include("utils.jl")
+include("random_planner.jl")
 
 # Register PDDL array theory
 println("Registering PDDL array theory")
@@ -13,7 +14,7 @@ PDDL.Arrays.register!()
 println("Loading domain")
 domain = load_domain(joinpath(@__DIR__, "domain.pddl"))
 println("Loading problem")
-problem = load_problem(joinpath(@__DIR__, "problems", "problem-2.pddl"))
+problem = load_problem(joinpath(@__DIR__, "problems", "problem-1.pddl"))
 
 # Initialize state and construct goal specification
 println("Initializing state")
@@ -29,7 +30,7 @@ domain, state = PDDL.compiled(domain, state)
 #--- Define Renderer ---#
 println("Defining renderer")
 # Construct gridworld renderer
-gem_colors = PDDLViz.colorschemes[:vibrant]
+
 renderer = PDDLViz.GridworldRenderer(
     resolution = (600, 700),
     agent_renderer = (d, s) -> begin
@@ -66,8 +67,9 @@ save("examples/vision/initial_state.png", canvas)
 #--- Visualize Plans ---#
 
 # Check that A* heuristic search correctly solves the problem
-planner = AStarPlanner(GoalManhattan(), save_search=true)
-sol = planner(domain, state, spec)
+random_planner = RandomPlanner(save_search=true)
+# astar_planner = AStarPlanner(GoalManhattan(), save_search=true)
+sol = random_planner(domain, state, spec)
 
 # Visualize resulting plan
 plan = collect(sol)

--- a/examples/vision/example.jl
+++ b/examples/vision/example.jl
@@ -74,13 +74,10 @@ sol1 = random_planner(domain, state, pddl"(visible carrot1)")
 sol2 = astar_planner(domain, sol1.trajectory[end], pddl"(has carrot1)")
 plan = [collect(sol1); collect(sol2);]
 
-# sol = random_planner(domain, state, spec)
-# plan = collect(sol)
-
 obs_traj = PDDL.simulate(domain, state, plan)
 
 # Visualize trajectory
 anim = anim_plan(renderer, domain, state, plan;
-                 format="gif", framerate=5, trail_length=10)
+                 format="gif", framerate=2, trail_length=10)
 
-save("examples/vision/plan.mp4", anim)
+save("examples/vision/plan_.mp4", anim)

--- a/examples/vision/example.jl
+++ b/examples/vision/example.jl
@@ -68,27 +68,18 @@ save("examples/vision/initial_state.png", canvas)
 
 # Check that A* heuristic search correctly solves the problem
 random_planner = RandomPlanner(save_search=true)
-# astar_planner = AStarPlanner(GoalManhattan(), save_search=true)
-sol = random_planner(domain, state, spec)
+astar_planner = AStarPlanner(GoalManhattan(), save_search=true)
 
-# Visualize resulting plan
-plan = collect(sol)
+sol1 = random_planner(domain, state, pddl"(visible carrot1)")
+sol2 = astar_planner(domain, sol1.trajectory[end], pddl"(has carrot1)")
+plan = [collect(sol1); collect(sol2);]
 
+# sol = random_planner(domain, state, spec)
+# plan = collect(sol)
 
-# Print visibility status after each step in the plan
-for (i, step) in enumerate(plan)
-    println("Step $i: $step")
-    local current_state = sol.trajectory[i]
-    println("Current state: $current_state")
-end
+obs_traj = PDDL.simulate(domain, state, plan)
 
-canvas = renderer(canvas, domain, state, plan)
-@assert satisfy(domain, sol.trajectory[end], problem.goal) == true
-
-# Visualise search tree
-canvas = renderer(canvas, domain, state, sol, show_trajectory=false)
-
-# Animate plan
+# Visualize trajectory
 anim = anim_plan(renderer, domain, state, plan;
                  format="gif", framerate=5, trail_length=10)
 

--- a/examples/vision/random_planner.jl
+++ b/examples/vision/random_planner.jl
@@ -144,7 +144,6 @@ function expand!(
     if isempty(unvisited_and_available_actions)
         unvisited_and_available_actions = available_actions
     end
-    println("unvisited_and_available_actions: ", unvisited_and_available_actions)
 
     # Randomly select actions and transitions
     chosen_action = unvisited_and_available_actions[rand(1:length(unvisited_and_available_actions))]

--- a/examples/vision/random_planner.jl
+++ b/examples/vision/random_planner.jl
@@ -40,6 +40,10 @@ function (planner::RandomPlanner)(domain::Domain, state::State, spec::Specificat
     solve(planner, domain, state, spec)
 end
 
+function (planner::RandomPlanner)(domain::Domain, state::State, goals)
+    solve(planner, domain, state, Specification(goals))
+end
+
 function Base.copy(p::RandomPlanner)
     return RandomPlanner(p.max_nodes, p.max_time,
                          p.save_search, p.save_search_order,

--- a/examples/vision/random_planner.jl
+++ b/examples/vision/random_planner.jl
@@ -1,0 +1,139 @@
+using Base: @kwdef
+using Parameters: @unpack
+using SymbolicPlanners, Plinf
+using SymbolicPlanners: PathNode, simplify_goal, LinkedNodeRef, @auto_hash, @auto_equals, reconstruct
+using PDDL
+
+"""
+    RandomPlanner(;
+        max_nodes::Int = typemax(Int),
+        max_time::Float64 = Inf,
+        save_search::Bool = false,
+        save_search_order::Bool = save_search,
+        verbose::Bool = false,
+        callback = verbose ? LoggerCallback() : nothing
+    )
+
+Random search planner. Nodes are expanded in a random order.
+
+Returns a [`PathSearchSolution`](@ref) or [`NullSolution`](@ref).
+"""
+# @kwdef mutable struct RandomPlanner <: Planner
+mutable struct RandomPlanner
+    max_nodes::Int
+    max_time::Float64
+    save_search::Bool
+    save_search_order::Bool
+    verbose::Bool
+    callback::Union{Nothing, Function}
+
+    RandomPlanner(;max_nodes::Int=typemax(Int), max_time::Float64=Inf,
+                  save_search::Bool=false, save_search_order::Bool=save_search,
+                  verbose::Bool=false, callback::Union{Nothing, Function}=verbose ? LoggerCallback() : nothing) =
+        new(max_nodes, max_time, save_search, save_search_order, verbose, callback)
+end
+
+@auto_hash RandomPlanner
+@auto_equals RandomPlanner
+
+function (planner::RandomPlanner)(domain::Domain, state::State, spec::Specification)
+    solve(planner, domain, state, spec)
+end
+
+function Base.copy(p::RandomPlanner)
+    return RandomPlanner(p.max_nodes, p.max_time,
+                         p.save_search, p.save_search_order,
+                         p.verbose, p.callback)
+end
+
+function solve(planner::RandomPlanner,
+               domain::Domain, state::State, spec::Specification)
+
+    @unpack save_search = planner
+    spec = simplify_goal(spec, domain, state)
+    node_id = hash(state)
+    node = PathNode(node_id, state, 0.0, LinkedNodeRef(node_id))
+
+    search_tree = Dict(node_id => node)
+    queue = [node_id]
+    search_order = UInt[]
+    sol = PathSearchSolution(:in_progress, Term[], Vector{typeof(state)}(),
+                             0, search_tree, queue, search_order)
+    sol = search!(sol, planner, domain, spec)
+
+    if save_search
+        return sol
+    elseif sol.status == :failure
+        return NullSolution(sol.status)
+    else
+        return PathSearchSolution(sol.status, sol.plan, sol.trajectory)
+    end
+end
+
+function search!(sol::PathSearchSolution, planner::RandomPlanner,
+                 domain::Domain, spec::Specification)
+    start_time = time()
+    sol.expanded = 0
+    queue, search_tree = sol.search_frontier, sol.search_tree
+
+    while length(queue) > 0
+        # Randomly select a state from the queue
+        node_id = queue[rand(1:end)]
+        node = search_tree[node_id]
+
+        if is_goal(spec, domain, node.state, node.parent.action)
+            sol.status = :success # Goal reached
+        elseif sol.expanded >= planner.max_nodes
+            sol.status = :max_nodes # Node budget reached
+        elseif time() - start_time >= planner.max_time
+            sol.status = :max_time # Time budget reached
+        end
+
+        if sol.status == :in_progress # Expand current node
+            popfirst!(queue)
+            expand!(planner, node, search_tree, queue, domain, spec)
+            sol.expanded += 1
+            if planner.save_search && planner.save_search_order
+                push!(sol.search_order, node_id)
+            end
+            if !isnothing(planner.callback)
+                planner.callback(planner, sol, node_id, sol.expanded)
+            end
+        else # Reconstruct plan and return solution
+            sol.plan, sol.trajectory = reconstruct(node_id, search_tree)
+            if !isnothing(planner.callback)
+                planner.callback(planner, sol, node_id, sol.expanded)
+            end
+            return sol
+        end
+    end
+    sol.status = :failure
+    return sol
+end
+
+
+function expand!(
+    planner::RandomPlanner, node::PathNode{S},
+    search_tree::Dict{UInt,PathNode{S}}, queue::Vector{UInt},
+    domain::Domain, spec::Specification
+) where {S <: State}
+    state = node.state
+
+    available_actions = [act for act in available(domain, state) if !haskey(search_tree, hash(transition(domain, state, act, check=false)))]
+    println("available_actions: ", available_actions)
+    if isempty(available_actions)
+        return  # Return if there is no direction to proceed
+    end
+
+    # Randomly select actions and transitions
+    chosen_action = available_actions[rand(1:length(available_actions))]
+    next_state = transition(domain, state, chosen_action, check=false)
+    next_id = hash(next_state)
+
+    # Add new state to search tree and queue
+    if !haskey(search_tree, next_id)
+        path_cost = node.path_cost + 1
+        search_tree[next_id] = PathNode(next_id, next_state, path_cost, LinkedNodeRef(node.id, chosen_action))
+        push!(queue, next_id)
+    end
+end


### PR DESCRIPTION
## Changes
- Search method depends on the agent is seeing carrot or not.
  - The agent searches randomly until sees a carrot, and when the agent see it, goes for it.
- The random search takes the path not taken as much as possible.
  - If the agent have visited all the places the agent can go, it go through the same place again.

## Point of Concern
- The agent may pick up objects that are not goals too.
  - Is this not a problem?


## Tips
- The implementation of randomplanner was based on [bfs.jl](https://github.com/JuliaPlanners/SymbolicPlanners.jl/blob/master/src/planners/bfs.jl).